### PR TITLE
HLS v6 issue - disable http_persistent

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -2411,7 +2411,7 @@ static const AVOption hls_options[] = {
     {"max_reload", "Maximum number of times a insufficient list is attempted to be reloaded",
         OFFSET(max_reload), AV_OPT_TYPE_INT, {.i64 = 1000}, 0, INT_MAX, FLAGS},
     {"http_persistent", "Use persistent HTTP connections",
-        OFFSET(http_persistent), AV_OPT_TYPE_BOOL, {.i64 = 1}, 0, 1, FLAGS },
+        OFFSET(http_persistent), AV_OPT_TYPE_BOOL, {.i64 = -1}, 0, 1, FLAGS },
     {"http_multiple", "Use multiple HTTP connections for fetching segments",
         OFFSET(http_multiple), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, FLAGS},
     {"hls_io_protocol", "force segment io protocol",


### PR DESCRIPTION
http_persistent:1 breaks FFMPEG versions between 4.0~4.2.*